### PR TITLE
Adding Window-leftNavButtons and Window-rightNavButtons support

### DIFF
--- a/controllers/widget.js
+++ b/controllers/widget.js
@@ -1,5 +1,5 @@
 /**
- * @file widget.js 
+ * @file widget.js
  * @namespace Widget
  * @author Matthew McFarland
  * @summary com.mattmcfarland.fontawesome
@@ -16,46 +16,46 @@
 
 // --------------------------------------------
 //
-// Public Properties (AKA "Members") 
+// Public Properties (AKA "Members")
 // ============================================
 
 /**
  * @name debugMode
- * @public 
+ * @public
  * @since v1.0.0
  * @memberOf Widget#
  * @type {Boolean}
  *
  * @summary Toggle debugMode.
- * 
+ *
  * @default false
- * 
- * @desc 
- * If enabled, prints debug output to console if your log level is at debug. 
- * 
- * @example $.fa.debugMode = true; 
- * 
+ *
+ * @desc
+ * If enabled, prints debug output to console if your log level is at debug.
+ *
+ * @example $.fa.debugMode = true;
+ *
  */
-exports.debugMode; 
+exports.debugMode;
 
 /**
  * @name icons
- * @public 
+ * @public
  * @since v1.2.0
  * @type {Object}
  * @memberOf Widget#
- * @summary Set a custom charmap.js file. 
+ * @summary Set a custom charmap.js file.
  *
  * @default require(WPATH('icons'));
- * 
- * @desc 
- * Add your own icon character map if you want to use custom icons. 
+ *
+ * @desc
+ * Add your own icon character map if you want to use custom icons.
  * It is recommended that you have a basic understanding of how to add custom fonts with Titanium Alloy.
  * Because Android, IOS, and mobileweb interpret font files differently, you should read up on the custom font docs.
  * Once you put your font files in the proper assets directory, you can must /require/ your character map in your lib folder.
- * 
+ *
  * IMPORTANT: Set parse to false for best results.
- * 
+ *
  * @example <caption>Titanium:</caption>
  *	var glyph = Alloy.createWidget("com.mattmcfarland.fontawesome");
  *	var glyphicons = require('glyphicons');
@@ -63,59 +63,59 @@ exports.debugMode;
  * 	win.add(glyph);
  * @example <caption>Alloy:</caption>
  *  <Widget id = "fa" src = "com.mattmcfarland.fontawesome" icons = "require('glyphicons')" />
- * 	
+ *
  */
 exports.icons;
 
 /**
  * @name iconPrefex
- * @public 
+ * @public
  * @memberOf Widget#
  * @since v1.2.0
  * @type {String}
- * 
+ *
  * @summary Prefix for parser.
  *
  * @default 'icons.iconPrefix-' ('fa-')
  *
- * @desc 
+ * @desc
  * The iconPrefix property declares what the parser should look for when applying icons to View elements.
  * Therefore, it only will parse view elements that have an icon property with the declared value.
- * 
- * > IMPORTANT: This will override any settings in your custom icons.js 
- * 
+ *
+ * > IMPORTANT: This will override any settings in your custom icons.js
+ *
  * @example <caption>Titanium:</caption>
  *	var glyph = Alloy.createWidget("com.mattmcfarland.fontawesome");
  *	var glyph.iconPrefix = 'glyph-'
  * 	win.add(glyph);
- * 
+ *
  * @example <caption>Alloy:</caption>
  *  <Widget src = "com.mattmcfarland.fontawesome" iconPrefix = "glyph-" />
  *  <Label icon = "gylph-star"/>
- * 	
+ *
  */
-exports.iconPrefix; 
+exports.iconPrefix;
 
 /**
  * @name instaParse
- * @public 
+ * @public
  * @since v1.2.0
  * @type Boolean
  * @memberOf Widget#
- * 
+ *
  * @summary Configure if Parser starts immediately.
- * 
+ *
  * @default true
- * 
- * @desc 
+ *
+ * @desc
  * When enabled (and is by default), widget will parse viewport (excluding parent objects!) for icons immediately.
- * If you wish to parse the document at a later time (after data is loaded), set it to false then call the `init()` method. 
- * 
+ * If you wish to parse the document at a later time (after data is loaded), set it to false then call the `init()` method.
+ *
  * @example <caption>Titanium:</caption>
  *	var fa = Alloy.createWidget("com.mattmcfarland.fontawesome");
  *  fa.instaParse = false;
  * 	win.add(fa);
- * 
+ *
  * @example <caption>Alloy (index.xml):</caption>
  *	<Alloy>
  *		<Window id = "index">
@@ -124,14 +124,14 @@ exports.iconPrefix;
  *			<Widget id="fa" src = "com.mattmcfarland.fontawesome" instaParse = "false" />
  *		<Window>
  *	</Alloy>
- * @example <caption>Alloy (index.js):</caption> 
+ * @example <caption>Alloy (index.js):</caption>
  *	$.index.open()
  *	// Do Stuff
  *	// Do More Stuff
  *	// Ok, Now Parse!
  *	$.fa.refresh()
  */
-exports.instaParse; 
+exports.instaParse;
 
 // --------------------------------------------
 //
@@ -145,13 +145,13 @@ exports.instaParse;
  * @since v1.1.0
  * @memberOf Widget#
  * @summary Add a new Icon
- * 
+ *
  * @param {Ti.UI.View} el - Create and Prepend To Target Element (label, button, view, etc)
  * @param {String} icon - font-awesome icon (ie: "fa-flag")
- * 
- * @desc 
+ *
+ * @desc
  * Adds an Icon to an existing view element and prepends it to the title or text.
- * 
+ *
  * @example $.fa.add(MyLabel,"fa-star")
  */
 exports.add = function(el,icon) {
@@ -159,21 +159,21 @@ exports.add = function(el,icon) {
 };
 
 /**
- * @public 
- * @method 
+ * @public
+ * @method
  * @name remove(el)
  * @since v1.1.0
  * @memberOf Widget#
- * 
+ *
  * @summary Remove an Icon
  *
  * @param {Ti.UI.View} el - Removes icon property from target element and from text/title.
- * 
- * @desc 
+ *
+ * @desc
  * Removes an Icon from an existing view element.
- * 
+ *
  * @example $.fa.remove(MyButton)
- * 
+ *
  */
 exports.remove = function(el) {
 	destroyIcon(el);
@@ -186,19 +186,19 @@ exports.remove = function(el) {
  * @name change(el,icon)
  * @since v1.1.0
  * @memberOf Widget#
- * 
+ *
  * @summary Changes an Icon
- * 
+ *
  * @param {Ti.UI.View} el - Element with existing icon property (label, button, view, etc)
  * @param {String} icon - Change existing icon property to (e.g. : "fa-flag")
- * 
- * @desc 
+ *
+ * @desc
  * Changes an already existing Icon to another Icon on an existing view element.
- * 
- * @example $.fa.change(MyLabel, "fa-flag")  
+ *
+ * @example $.fa.change(MyLabel, "fa-flag")
  */
 exports.change = function(el,icon) {
-	changeIcon(el,icon);	
+	changeIcon(el,icon);
 };
 
 /**
@@ -206,16 +206,16 @@ exports.change = function(el,icon) {
  * @method
  * @name refresh
  * @memberOf Widget#
- * 
+ *
  * @summary Parse and apply icons in view.
- * 
- * @desc 
- * Parse existing viewport along with siblings and descendants for icon properties 
- * that only have the proper prefix (default 'fa-'), then apply icons respectivly. 
- * 
+ *
+ * @desc
+ * Parse existing viewport along with siblings and descendants for icon properties
+ * that only have the proper prefix (default 'fa-'), then apply icons respectivly.
+ *
  * > IMPORTANT: MUST be ran if instaParse is set to false!
- * 
- * 
+ *
+ *
  * @example $.fa.refresh();
  */
 exports.refresh = function(){applyIcons();};
@@ -226,42 +226,42 @@ exports.refresh = function(){applyIcons();};
 // ============================================
 
 /**
- * @private 
+ * @private
  * @since 1.0.0
- * 
+ *
  * Find all siblings / children of existing widget and
  * apply icons to any item with 'icon' property containing 'fa-' prefix.
  */
 function applyIcons() {
     function updateIcons(children) {
-        
+
         // Iterate tags
         if (children) {
             children.forEach(function (tag) {
-                
+
                 // Debugging stuff
                 counter++;
                 if (debugMode) Ti.API.debug('['+counter+'] ('+tag['id']+')  Checking for icon attribute');
                 //.../Debugging stuff
                 // Add or change Icon if user changes the ['icon'] property.
 
-                
+
                 // If current tag has an icon property
                 if (tag['icon']) {
                     var iconChar = icons.charMap[tag['icon']];
-                    
+
                     if (debugMode) Ti.API.debug('['+counter+'] ('+tag['id']+')  icon attribute found. value is "'+tag['icon']+'"');
-                                        
-                    //Only handle icons that use 'fa-' prefix					
+
+                    //Only handle icons that use 'fa-' prefix
                     if (tag['icon'].substring(0, 3) === "fa-") {
-                        
+
                         if (debugMode) Ti.API.debug('['+counter+'] ('+tag['id']+')  fa- prefix found');
-                        
+
                         addIcon(tag,iconChar);
                     }
                 }
                 // think about the children!
-                updateIcons(tag.views || tag.children);
+                updateIcons(tag.leftNavButtons || tag.rightNavButtons || tag.views || tag.children);
             });
         }
     }
@@ -270,24 +270,24 @@ function applyIcons() {
 }
 
 /**
- * @private 
+ * @private
  * @since v1.1.0
- * 
+ *
  * Remove an Icon from a view, then remove any special characters (which are hopefully icon!) from text/title
  * @param {Ti.UI.View} tag - view element to remove..
  */
 function removeIcon(tag) {
 	if (tag.icon) tag.icon = '';
 	if (tag.text) tag.text = removeChars(tag.text);
-	if (tag.title) tag.text = removeChars(tag.title);	
+	if (tag.title) tag.text = removeChars(tag.title);
 }
 
 /**
- * @private 
+ * @private
  * @since v1.1.0
- * 
+ *
  * Helper: Remove special characters
- * 
+ *
  * @param {String} string - REGEX this.
  * @returns {String} new string without special characters.
  */
@@ -296,31 +296,31 @@ function removeChars(string) {
 }
 
 /**
- * @private 
+ * @private
  * @since v1.0.0
- * 
+ *
  * Adds Icon to tags text/title, set font property and preserve font sizing.
- * 
+ *
  * @param {Ti.UI.View} tag - View elem to add to
  * @param {String} iconChar - Font Character String
  */
 function addIcon(tag,iconChar) {
-	
+
     // Set title/text caches to hold icon character.
     var aText = iconChar;
     var aTitle = iconChar;
     var fSize = icons.defaultSize;
-    
+
     // Preserve existing text and title properties, if they exist.
-    // by appending original text/title to new text/title that only has icon char. 
+    // by appending original text/title to new text/title that only has icon char.
     if (tag['text']) aText += ' ' + tag['text'];
     if (tag['title']) aTitle += ' ' + tag['title'];
-    
+
     // Debugging stuff
     if (debugMode) Ti.API.debug('['+counter+'] aText = "'+aText+'"');
     if (debugMode) Ti.API.debug('['+counter+'] aTitle = "'+aTitle+'"');
-    
-    
+
+
     // Preserve existing font size, if it is configured.
     if (tag['font']) {
         if (tag['font']['fontSize']) {
@@ -331,7 +331,7 @@ function addIcon(tag,iconChar) {
             fSize = tag['font']['iconFontSize'];
         }
     }
-    
+
     // Configure new properties
     var props = {
         font: {
@@ -341,10 +341,10 @@ function addIcon(tag,iconChar) {
         text: aText,
         title: aTitle,
     };
-    
-    // Apply properties 
+
+    // Apply properties
     tag.applyProperties(props);
-    
+
     // Debugging stuff
     if (debugMode) {
         Ti.API.debug(tag.getFont()['fontFamily']);
@@ -352,15 +352,15 @@ function addIcon(tag,iconChar) {
             Ti.API.debug('['+counter+'] ('+tag['id']+') {'+p+'} value is "'+tag[p]+'"');
         }
     }
-	
+
 }
 
 /**
- * @private 
+ * @private
  * @since v1.1.0
- * 
+ *
  * Prepends an Icon to a Ti.UI.View Element.
- * 
+ *
  * @param {Ti.UI.View} el - Create and Prepend To Target Element (label, button, view, etc)
  * @param {String} iconName - font-awesome icon string (ie: fa-flag)
  */
@@ -372,21 +372,21 @@ function createIcon(el,iconName) {
 
 
 /**
- * @private 
+ * @private
  * @since v1.1.0
- * 
+ *
  * Removes .icon property from view and strips from .title or .text property.
- * 
+ *
  * @param {Ti.UI.View} el - Remove from Target Element (label, button, view, etc)
  */
 function destroyIcon(el) {
-    removeIcon(el);	
+    removeIcon(el);
 }
 
 
 /**
- * @private 
- * 
+ * @private
+ *
  * @param {Ti.UI.View} el - Remove & Replace Icon
  * @param {String} iconName - New Icon string.
  */


### PR DESCRIPTION
I was struggling getting my buttons styled in the Nav Bar on iOS with your plugin.
This way it will not stop if a UI Element has the property `leftNavButtons` or `rightNavButtons` set with some children in it. This is the case of the Window UI Element in some cases. Then the rest of the tree element will be parse as usual and be styled by your plugin (which is pretty awesome btw).