### PR TITLE
icon.js  bug fixed

### DIFF
--- a/lib/icons.js
+++ b/lib/icons.js
@@ -734,8 +734,8 @@ exports.charMap = new Array;
     ["fa-houzz", 62076],
     ["fa-vimeo", 62077],
     ["fa-black-tie", 62078],
-    ["fa-fonticons", 62080]
-    ["fa-reddit-alien", 62081]
+    ["fa-fonticons", 62080],
+    ["fa-reddit-alien", 62081],
     ["fa-edge", 62082],
     ["fa-credit-card-alt", 62083],
     ["fa-codiepie", 62084],


### PR DESCRIPTION
icon.js gives error.

[ERROR] :  TypeError: undefined is not an object (evaluating '[ "fa-fonticons", 62080 ][("fa-reddit-alien",
[ERROR] :  62081)][("fa-edge", 62082)]')
[ERROR] :  File: com.mattmcfarland.fontawesome/icons.js
[ERROR] :  Line: 10
[ERROR] :  SourceId: <null>
[ERROR] :  Backtrace:
[ERROR] :   undefined