### PR TITLE
Fixed Typo

### DIFF
--- a/lib/icons.js
+++ b/lib/icons.js
@@ -258,7 +258,7 @@ exports.charMap = new Array;
     ["fa-copy", 61637],
     ["fa-files-o", 61637],
     ["fa-paperclip", 61638],
-    ["fa-save", 61633],
+    ["fa-save", 61639],
     ["fa-floppy-o", 61639],
     ["fa-square", 61640],
     ["fa-navicon", 61641],


### PR DESCRIPTION
fa-save (alias) was using fa-link/fa-chain opposed to fa-floppy-o (correct value)